### PR TITLE
add ability to extend ShiroAnnotationHandlerService

### DIFF
--- a/grails-app/services/org/apache/shiro/grails/ShiroAnnotationHandlerService.groovy
+++ b/grails-app/services/org/apache/shiro/grails/ShiroAnnotationHandlerService.groovy
@@ -8,9 +8,9 @@ import org.springframework.beans.factory.InitializingBean
 class ShiroAnnotationHandlerService implements InitializingBean {
     def grailsApplication
 
-    private authcHandlers
-    private authzHandlers
-    private handlerMap
+    protected authcHandlers
+    protected authzHandlers
+    protected handlerMap
 
     /**
      * Loads all the controller classes in the application and scans them for
@@ -39,7 +39,7 @@ class ShiroAnnotationHandlerService implements InitializingBean {
     }
 
 
-    private void processController(controllerClass) {
+    protected void processController(controllerClass) {
         def authcAnnotations = authcHandlers.keySet()
         def authzAnnotations = authzHandlers.keySet()
 


### PR DESCRIPTION
I changed private to protected on the AnnotationHandler in order to drop "static transactional = false" onto the service bean.

User story: I've ripped Hibernate out of my Grails app and am going with Shiro's native mode, but the default of transactional=true forces Hibernate to be present.
