### PR TITLE
Enable the developer to disable the savedRequest functionality...

### DIFF
--- a/ShiroGrailsPlugin.groovy
+++ b/ShiroGrailsPlugin.groovy
@@ -476,7 +476,11 @@ Adopted from previous JSecurity plugin.
                 // Save the request if this is a POST so we don't lose
                 // the data after a redirect. The other part of the
                 // POST handling is in the ...Filter.
-                if (request.method == "POST") {
+                def enableSavedRequests = ConfigurationHolder.config.security.shiro.redirect.enableSavedRequests
+                if (enableSavedRequests instanceof ConfigObject) {
+                    enableSavedRequests = true
+                }
+                if (request.method == "POST" && enableSavedRequests) {
                     filter.session["shiroGrailsSavedRequest"] = new SavedHttpServletRequest(request)
 
                     if (!query) targetUri << '?'


### PR DESCRIPTION
... via the 'security.shiro.redirect.enableSavedRequests' config setting, which defaults to true. This is useful for environments with clustered sessions which require all objects in the session to be [de]serializable, which the base HttpServletRequestWrapper is not (as it doesn't have a no-arg constructor). This would address the issue described in http://jira.grails.org/browse/GPSHIRO-55.

I'm happy to spend a bit of time on this, so if you can think of a fix that does not involve disabling this functionality, the please let me know.

Thanks,

Adam
