### PR TITLE
Correctly URL encoding the targetUri when a custom redirectURI is specified.

### DIFF
--- a/ShiroGrailsPlugin.groovy
+++ b/ShiroGrailsPlugin.groovy
@@ -486,7 +486,7 @@ Adopted from previous JSecurity plugin.
 
                 def redirectUri = ConfigurationHolder.config.security.shiro.redirect.uri
                 if (redirectUri) {
-                    filter.redirect(uri: redirectUri + "?targetUri=${targetUri}")
+                    filter.redirect(uri: redirectUri + "?targetUri=${targetUri.encodeAsURL()}")
                 }
                 else {
                     filter.redirect(


### PR DESCRIPTION
This is a tiny commit that fixes a bug I discovered when adding the enableSavedRequests config flag.
