### PR TITLE
Corrected type argument usage at principal method

### DIFF
--- a/grails-app/taglib/org/apache/shiro/grails/ShiroTagLib.groovy
+++ b/grails-app/taglib/org/apache/shiro/grails/ShiroTagLib.groovy
@@ -123,7 +123,7 @@ class ShiroTagLib {
             if (attrs["type"]) {
                 // A principal of a particular type/class has been
                 // requested.
-                principal = subject.principals.oneByType(attrs["type"])
+                principal = subject.principals.oneByType(Class.forName(attrs["type"]))
             }
             else {
                 principal = subject.principal


### PR DESCRIPTION
This patch solves the following error that occurs when using the type argument at the principal method from the ShiroTagLib:  
Error executing tag shiro:principal: groovy.lang.MissingMethodException: No signature of method: org.apache.shiro.subject.SimplePrincipalCollection.oneByType() is applicable for argument types: (java.lang.String)
