### PR TITLE
Fixed plugin dependency @ BuildConfig.groovy

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -25,8 +25,8 @@ grails.project.dependency.resolution = {
         }
     }
     plugins {
-        runtime ":hibernate:$grailsVersion"
-        build (":tomcat:$grailsVersion",
+        runtime ":hibernate:3.6.10.6"
+        build (":tomcat:7.0.47",
                 ":release:2.2.1") {
             export = false
         }


### PR DESCRIPTION
$grailsVersion causes error when resolving dependencies since there is no hibernate/tomcat plugin that have the same version with $grailsVersion

I'm using the latest available version for both hibernate and tomcat plugin
