### PR TITLE
Added "hasAnyPermission" TagLib

### DIFF
--- a/grails-app/taglib/org/apache/shiro/grails/ShiroTagLib.groovy
+++ b/grails-app/taglib/org/apache/shiro/grails/ShiroTagLib.groovy
@@ -256,6 +256,26 @@ class ShiroTagLib {
         }
     }
 
+
+    /**
+     * This tag only writes its body to the output if the current user
+     * have any of the given permissions provided in a separated comma String.
+     */
+    def hasAnyPermission = { attrs, body ->
+        def permissions = attrs["permissions"]
+        if (!permissions){
+            throwTagError("Tag [hasAnyPermission] must have [permissions] attribute")
+        }
+        def permissionsList = permissions.split(',')
+        for (permission in permissionsList) {
+            if (checkPermission([permission: permission], "hasPermission")) {
+                // Output the body text.
+                out << body()
+                return out
+            }
+        }
+    }
+
     /**
      * Checks whether the current user is authenticated or not. Returns
      * <code>true</code> if the user is authenticated, otherwise


### PR DESCRIPTION
I've created a new tag that checks if the user has any of the permissions given.
The tag need the attribute "permissions" that should be a separated comma string with the permissions
This tag its very usefull in menus, for example:

```
<shiro:hasAnyPermission permissions="manage:user,manage:roles">
    <ul>
        <shiro:hasPermission permission="manage:user"><li>users</li></shiro:hasPermission>
        <shiro:hasPermission permission="manage:roles"><li>roles</li></shiro:hasPermission>
    </ul>
</shiro:hasAnyPermission>
```