### PR TITLE
Allow native sessions in grails >= 2.3.

### DIFF
--- a/shiro2/ShiroGrailsPlugin.groovy
+++ b/shiro2/ShiroGrailsPlugin.groovy
@@ -134,7 +134,7 @@ Enables Grails applications to take advantage of the Apache Shiro security layer
             // Allow the user to customise the session type: 'http' or
             // 'native'.
             if (securityConfig.session.mode) {
-                sessionManager = createSessionManager(securityConfig.session.mode)
+                sessionManager = ShiroGrailsPlugin.createSessionManager(securityConfig.session.mode)
             }
 
             // Allow the user to provide his own versions of these


### PR DESCRIPTION
security.shiro.session.mode = 'native' cannot be used in grails >= 2.3. When you try to `grails run-app`, an exception occurs:

```
Caused by IllegalStateException: Cannot convert value of type [grails.spring.BeanBuilder] to required type [org.apache.shiro.session.mgt.SessionManager] for property 'sessionManager': no matching editors or conversion strategy found
```

Solution is to be explicit that `createSessionManager` is a static method and not a part of bean DSL.