### PR TITLE
Update Travis badge to point at pledbrook instead of Arkilog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 Grails 3 Shiro plugin
 =====================
 
-[![Build Status](https://api.travis-ci.org/Arkilog/grails-shiro.png)](http://travis-ci.org/Arkilog/grails-shiro)
+[![Build Status](https://api.travis-ci.org/pledbrook/grails-shiro.png)](http://travis-ci.org/pledbrook/grails-shiro)


### PR DESCRIPTION
fixes #60

@pledbrook, will you enable travis for grails-shiro?
